### PR TITLE
Fix issue where adding a message stream would return error from API

### DIFF
--- a/src/TemplateMessage.php
+++ b/src/TemplateMessage.php
@@ -80,10 +80,9 @@ final class TemplateMessage
     public ?array $metadata = null;
 
     /**
-     * @var string[]
      * @readonly
      */
-    public ?array $messageStream = null;
+    public ?string $messageStream = null;
 
     private function __construct(TemplateIdentifier $identifier, ?TemplateModel $model = null)
     {
@@ -220,7 +219,7 @@ final class TemplateMessage
         return $instance;
     }
 
-    public function messageStream(string ...$messageStream): self
+    public function messageStream(string $messageStream): self
     {
         $instance = $this->copy();
         $instance->messageStream = $messageStream;

--- a/src/TemplateMessageTest.php
+++ b/src/TemplateMessageTest.php
@@ -229,9 +229,9 @@ final class TemplateMessageTest extends TestCase
     public function itAcceptsOptionalMessageStream(): void
     {
         $originalMessage = TemplateMessage::fromAlias($this->faker->word);
-        $messageStream = [$this->faker->word, $this->faker->word];
+        $messageStream = $this->faker->word;
 
-        $message = $originalMessage->messageStream(...$messageStream);
+        $message = $originalMessage->messageStream($messageStream);
 
         $this->assertNull($originalMessage->messageStream);
         $this->assertSame($messageStream, $message->messageStream);


### PR DESCRIPTION
According to the api docs the message streams param in de template message needs to be in string format. Otherwise the api will return an error message

<img width="337" alt="Screenshot 2022-05-10 at 13 35 33" src="https://user-images.githubusercontent.com/13765389/167623183-041ab024-06d7-4083-882a-cff2e6b26a17.png">
